### PR TITLE
Fitter can now run in silent plot mode.

### DIFF
--- a/_data.py
+++ b/_data.py
@@ -825,7 +825,8 @@ class fitter():
         """
         for k in kwargs.keys(): self[k] = kwargs[k]
 
-        if self['autoplot']: self.plot()
+        if self._settings['autoplot'][0]: 
+            self.plot()
 
         return self
 
@@ -1574,7 +1575,8 @@ class fitter():
 
         # now show the update.
         self._clear_results()
-        if self['autoplot']: self.plot()
+        if self._settings['autoplot'][0]: 
+            self.plot()
 
         return self
 
@@ -1605,7 +1607,8 @@ class fitter():
 
         # now show the update.
         self._clear_results()
-        if self['autoplot']: self.plot()
+        if self._settings['autoplot'][0]: 
+            self.plot()
 
         return self
 


### PR DESCRIPTION
In fitter self._settings['autoplot'] is a list of two elements.  This is always True.  To check for plotting fitter now looks at self._settings['autoplot'][0] to see if plots should be drawn.

@jaxankey , let me know if I am missing something.  This is not a great fix but it certainly gets the job done.  I didn't look into the details of why self._settings['autoplot'] is a list of two elements.  I probably should have just spent the time to figure out why this is the case and change accordingly.  I thought this was the safest bet to not break dependent code.
