### PR TITLE
Silent setting in fitter

### DIFF
--- a/_data.py
+++ b/_data.py
@@ -793,6 +793,7 @@ class fitter():
 
         # default settings
         self._settings = dict(autoplot      = True,     # whether we always plot when changing stuff
+                              silent        = False,    # whether text information is displayed
                               plot_fit      = True,     # include f in plots?
                               plot_bg       = False,    # include bg in plots?
                               plot_ey       = True,     # include error bars?
@@ -1132,8 +1133,11 @@ class fitter():
 
         # plot if not in silent mode
         if self['autoplot']: self.plot()
-
-        return self
+        
+        if self['silent'][0] == True: return None
+        else: return self
+#        return None  # Silent mode
+##        return self
 
     def set_guess_to_fit(self):
         """
@@ -1223,7 +1227,8 @@ class fitter():
         # plot if necessary
         if self['autoplot']: self.plot()
 
-        return self
+        if self['silent'][0] == True: return None
+        else: return self
 
     def fix(self, pname):
         """


### PR DESCRIPTION
Added a 'silent' option to _settings in fitter.  If True then the plot settings are not printed when sm.fit(), or sm.set_data() is called.

This can be improved.  This should probably set autoplot = False in the settings dict, for example.  Also, it is looking at the zeroth element of a list...  It works in limited use.

@jaxankey 