### PR TITLE
replace _thread with threading for Python 2 and 3 compatibility

### DIFF
--- a/_pylab_colormap.py
+++ b/_pylab_colormap.py
@@ -2,7 +2,7 @@ import os   as _os
 import matplotlib       as _mpl
 import pylab            as _pylab
 from functools import partial as _partial
-from . import _pylab_tweaks
+import _pylab_tweaks
 
 import spinmob as _s
 _qtw    = _s._qtw

--- a/_pylab_tweaks.py
+++ b/_pylab_tweaks.py
@@ -1,7 +1,7 @@
 import os                as _os
 import pylab             as _pylab
 import time              as _time
-import _thread            as _thread
+import threading         as _thread
 import matplotlib        as _mpl
 import numpy             as _n
 from . import _functions        as _fun
@@ -166,13 +166,13 @@ def differentiate_shown_data(neighbors=1, fyname=1, **kwargs):
 def fit_shown_data(f="a*x+b", p="a=1, b=2", axes="gca", **kwargs):
     """
     Fast-and-loos quick fit:
-    
+
     Loops over each line of the supplied axes and fits with the supplied
     function (f) and parameters (p). Assumes uniform error and scales this
     such that the reduced chi^2 is 1.
-    
+
     Returns a list of fitter objects
-    
+
     **kwargs are sent to _s.data.fitter()
     """
 
@@ -185,25 +185,25 @@ def fit_shown_data(f="a*x+b", p="a=1, b=2", axes="gca", **kwargs):
     ymin,ymax = axes.get_ylim()
 
     # update the kwargs
-    if 'first_figure' not in kwargs: kwargs['first_figure'] = axes.figure.number+1    
-    
+    if 'first_figure' not in kwargs: kwargs['first_figure'] = axes.figure.number+1
+
     # loop over the lines
     fitters = []
     for l in axes.lines:
-      
+
         # get the trimmed data
         x,y = l.get_data()
         x,y = _s.fun.trim_data_uber([x,y],[xmin<x,x<xmax,ymin<y,y<ymax])
-        
+
         # create a fitter
-        fitters.append(_s.data.fitter(f=f, p=p, **kwargs))        
+        fitters.append(_s.data.fitter(f=f, p=p, **kwargs))
         fitters[-1].set_data(x,y)
         fitters[-1].fit()
         fitters[-1].autoscale_eydata_and_fit()
         print(fitters[-1])
         print("<click the graph to continue>")
         fitters[-1].ginput(timeout=0)
-    
+
     return fitters
 
 def format_figure(figure=None, tall=False, draw=True):


### PR DESCRIPTION
change _plab_tweaks import so that it works (at least in Python 2).

A lot of test code errors, but tests at least now run in Python 2.  Would be good to know what happens now in Python 3.

@jaxankey , please see if test pass on a Python 3 system.