### PR TITLE
auto-stringify all functions supplied directly as callables to data.fitter instances

### DIFF
--- a/_data.py
+++ b/_data.py
@@ -1238,8 +1238,13 @@ class fitter():
                 self.f.append( eval('lambda ' + pstring + ': ' + f[n],  self._globals))
                 self._fnames.append(f[n])
             else:
-                self.f.append(f[n])
-                self._fnames.append(f[n].__name__)
+                if f[n].__name__ == (lambda: None).__name__:
+                    self._error('Providing a lambda as a fitting function is discouraged. Simple functions can be provided directly as strings.')
+                else:
+                    self._globals[f[n].__name__] = f[n]
+                    fn_argnames = 'x, ' + ', '.join(_inspect.getargspec(f[n])[0][1:])
+                    self.f.append(eval('lambda {}: {}({})'.format(pstring, f[n].__name__, fn_argnames), self._globals))
+                    self._fnames.append(f[n].__name__)
 
             # if bg[n] is a string, define a function on the fly.
             if isinstance(bg[n], str):
@@ -2184,4 +2189,4 @@ if __name__ == "__main__":
     import spinmob as sm
     d=sm.data.databox()
     x = d.load_file("C:\\Users\\jaxankey\\Miniconda3\\envs\\Python27-PyQt4\\Lib\\site-packages\\spinmob\\tests\\fixtures\\data\\mixed_complex_data.dat")
-    
+

--- a/_data.py
+++ b/_data.py
@@ -9,7 +9,7 @@ import pylab          as _p
 import textwrap       as _textwrap
 import spinmob        as _s
 import time           as _time
-
+import inspect        as _inspect
 
 
 

--- a/tests/test__data.py
+++ b/tests/test__data.py
@@ -220,6 +220,20 @@ class Test_fitter(_ut.TestCase):
         r = f.reduced_chi_squareds()
         self.assertIs(type(r), list)
         self.assertAlmostEqual(r[0], 1.5, 1)
+
+        # Try supplying a callable function
+        def tf(x, a1, a2, a3):
+            return a1 + a2*x + a3*x**2
+
+        f = _s.data.fitter(tf, 'a1=-1., a2=0.04, a3=0.00006', autoplot=False)
+        f.set_data(d[0], d[1], 0.05)
+        f.fit()
+        f.__repr__()
+
+        # See whether constants work as expected
+        f.fix(a1=-1.0)
+        f.fit()
+        f.__repr__()
         
 
         


### PR DESCRIPTION
Works towards resolving https://github.com/Spinmob/spinmob/issues/87.

Currently, this would be a breaking change in some edge cases, so more error handling and / or some sort of deprecation message might be necessary.