### PR TITLE
patched matplotlib backend use, compatability for jupyter notebook

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -4,7 +4,17 @@
 
 import os           as _os
 import sys          as _sys
-import matplotlib   as _mpl; _mpl.use('qtagg')
+import matplotlib   as _mpl
+try: _mpl.use('qtagg')
+except Exception as e:
+    print("WARNING: Failed to use 'qtagg' matplotlib backend. This may \
+be because you don't have the latest version either of Spinmob or \
+a Spinmob dependency. Try updating your libraries. This issue has been \
+known to occur in Jupyter Notebooks but may also be due to \
+incompatabilities with Apple's ARM silicon architecture.")
+    print(f"\nThe error that would have been raised is:\n{e}\n")
+    pass
+
 import pylab
 
 # WEIRD HACK THAT MAKES QT WORK IN SPYDER, WINDOWS CMD; no solution for pycharm :\


### PR DESCRIPTION
I copied [this issue](https://github.com/Spinmob/spinmob/issues/107) (which I opened) below. 

Jupyter notebook crashes upon importing spinmob because I don't have the correct backed `qtagg`. I suspect this is because I'm using an ARM machine and this particular mpl backend hasn't yet been ported. 

<img width="715" alt="Screen Shot 2023-01-30 at 5 18 27 PM" src="https://user-images.githubusercontent.com/21654151/215608486-1e300055-1b2d-4bd6-9702-97c48007d582.png">

I got around this by cloning the repo and importing it locally, and patching it with a try statement. Here is the piece of code causing the error, in the package's `__init__`

```python
import os           as _os
import sys          as _sys
import matplotlib   as _mpl; _mpl.use('qtagg')

import pylab
```

Here is a suggested patch:

```python
import os           as _os
import sys          as _sys
import matplotlib   as _mpl

try: 
    _mpl.use('qtagg')
except Exception as e: 
    print("WARNING: not using qtagg. This might be because you don't have the latest version either Spinmob or other dependencies. Try updating your libraries. This issue has also been known to occur in Jupyter Notebooks and possibly on ARM silicon architecture. Proceeding without a backend.")
    print(f"\nThe error that would have been raised is:\n{e}\n")
    pass

import pylab
```

I put the statement in question it into a try-catch block and issued a warning. Would you like me to submit a PR? Now the statement reads

<img width="1084" alt="Screen Shot 2023-01-30 at 5 26 40 PM" src="https://user-images.githubusercontent.com/21654151/215610069-4ecea2fc-beda-4284-af27-2652dacc82af.png">

Extra info: 
Before cloning and modifying the source, I first pip-installed the latest version of spinmob and have tried to install all the mpl's backends. 
