### PR TITLE
Uncomment numpy.NAN for compatibility

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -14,7 +14,7 @@ except Exception as e:
 
 import pylab
 import numpy
-#numpy.NAN = numpy.nan # Terrible thing we have to do until some libraries catch up with deprecation (added 2025-04-07)
+numpy.NAN = numpy.nan # Terrible thing we have to do until some libraries catch up with deprecation (added 2025-04-07)
 
 
 # WEIRD HACK THAT MAKES QT WORK IN SPYDER, WINDOWS CMD; no solution for pycharm :\


### PR DESCRIPTION
As discussed in #110, the deprecation of `numpy.NAN` appears to still cause issues even on recent versions of packages, and uncommenting the _hacky_ fix from f72e68e of `numpy.NAN=numpy.nan` seems to be a simple solution.
